### PR TITLE
Allow rails to use the fuzz_factor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ feature "viewing locations", js: true do
     expect(page).to look_like("books at Cambridge")
   end
 end
+
+feature "viewing locations with a fuzz factor", js: true do
+  scenario "should only show books at first location" do
+    visit location_path Location.find_by_name("Boston", fuzz_factor: 4)
+    expect(page).to look_like("books at Boston")
+  end
+end
 ```
 
 ### Fuzzy matching

--- a/lib/juxtapose/rspec.rb
+++ b/lib/juxtapose/rspec.rb
@@ -2,7 +2,7 @@ if defined?(RSpec::Matchers)
   RSpec::Matchers.define :look_like do |expected, options={}|
     match do |actual|
       if actual.respond_to?(:looks_like?)
-        actual.looks_like?(expected) == true
+        actual.looks_like?(expected, options[:fuzz_factor]) == true
       else
         matcher = ImageMatcher.new(options)
         matcher.identical?(expected, actual).tap do


### PR DESCRIPTION
Closes #22 

@thegreatape can you give this a review - specifically the addition of requires.  Neither of the `if defined?` functions were hitting the else condition not wiring up the matcher properly without them.  I am unsure if this would create a different issue though, so I'd like your thoughts on it.  Additionally if we are requiring them, we probably could just work with them rather than check if they are defined?

Or should the requires be something that should be put in `spec_helper` rather than directly in the gem, since we are not putting an actual dependency on the gems being used here?

I can remove the requires and handle that in another PR - just hit this roadblock while trying to work out this for #22 